### PR TITLE
Added CMDLINE parameter to skip lapic calibration.

### DIFF
--- a/arch/x86/kernel/apic/apic.c
+++ b/arch/x86/kernel/apic/apic.c
@@ -664,6 +664,16 @@ calibrate_by_pmtimer(long deltapm, long *delta, long *deltatsc)
 	return 0;
 }
 
+#ifdef CONFIG_VMMCP
+static int __init lapictimerfreq(char *str)
+{
+	get_option(&str, &lapic_timer_frequency);
+	return 0;
+}
+
+early_param("lapictimerfreq", lapictimerfreq);
+#endif
+
 static int __init calibrate_APIC_clock(void)
 {
 	struct clock_event_device *levt = this_cpu_ptr(&lapic_events);


### PR DESCRIPTION
Signed-off-by: GanShun ganshun@gmail.com
