### PR TITLE
Allow perf event setup and remove e820 custom region setup

### DIFF
--- a/arch/x86/kernel/cpu/perf_event.c
+++ b/arch/x86/kernel/cpu/perf_event.c
@@ -1688,9 +1688,7 @@ static int __init init_hw_perf_events(void)
 	default:
 		err = -ENOTSUPP;
 	}
-#ifdef CONFIG_VMMCP
-	err = -ENOTSUPP;
-#endif
+
 	if (err != 0) {
 		pr_cont("no PMU driver, software events only.\n");
 		return 0;

--- a/arch/x86/kernel/cpu/perf_event_intel_pt.c
+++ b/arch/x86/kernel/cpu/perf_event_intel_pt.c
@@ -1060,12 +1060,6 @@ static __init int pt_init(void)
 {
 	int ret, cpu, prior_warn = 0;
 
-#ifdef CONFIG_VMMCP
-	x86_add_exclusive(x86_lbr_exclusive_pt);
-	pr_warn("VMMCP, doing nothing\n");
-
-	return -EBUSY;
-#endif
 	BUILD_BUG_ON(sizeof(struct topa) > PAGE_SIZE);
 	get_online_cpus();
 	for_each_online_cpu(cpu) {

--- a/arch/x86/kernel/e820.c
+++ b/arch/x86/kernel/e820.c
@@ -1054,18 +1054,9 @@ char *__init default_machine_specific_memory_setup(void)
 		}
 
 		e820.nr_map = 0;
-#ifdef CONFIG_VMMCP
-		/* HACK. For now. */
-		printk("NOTE: -----------------------> hardwired memory 0 to 16M is reserved, 16M and up is memory. \n");
-		e820_add_region(0, 16*1048576, E820_RESERVED);
-		e820_add_region(16*1048576, 128*1048576, E820_RAM);
-		e820_add_region(4096*1048576, 2*1048576, E820_RAM);
-		e820_add_region(0xf0000000, 0x10000000, E820_RESERVED);
 
-#else
 		e820_add_region(0, LOWMEMSIZE(), E820_RAM);
 		e820_add_region(HIGH_MEMORY, mem_size << 10, E820_RAM);
-#endif
 	}
 
 	/* In case someone cares... */


### PR DESCRIPTION
Allow perf event setup to run now that we can handle attempts to access unsupported MSRs

Signed-off-by: Michael Taufen mtaufen@gmail.com
