### PR TITLE
Added cmdline parameter for TSC frequency

### DIFF
--- a/arch/x86/kernel/tsc.c
+++ b/arch/x86/kernel/tsc.c
@@ -1159,6 +1159,16 @@ static int __init init_tsc_clocksource(void)
  */
 device_initcall(init_tsc_clocksource);
 
+#ifdef CONFIG_VMMCP
+static int __init tsc_frequency(char *str)
+{
+	get_option(&str, &tsc_khz);
+	return 0;
+}
+
+early_param("tscfreq", tsc_frequency);
+#endif
+
 void __init tsc_init(void)
 {
 	u64 lpj;
@@ -1170,8 +1180,14 @@ void __init tsc_init(void)
 		setup_clear_cpu_cap(X86_FEATURE_TSC_DEADLINE_TIMER);
 		return;
 	}
-
+	#ifdef CONFIG_VMMCP
+	if (!tsc_khz) {
+		tsc_khz = x86_platform.calibrate_tsc();
+	}
+	#else
 	tsc_khz = x86_platform.calibrate_tsc();
+	#endif
+
 	cpu_khz = tsc_khz;
 
 	if (!tsc_khz) {

--- a/kernel/irq/irqdesc.c
+++ b/kernel/irq/irqdesc.c
@@ -107,7 +107,7 @@ printk("%s: insert %d\n", __func__, irq);
 
 struct irq_desc *irq_to_desc(unsigned int irq)
 {
-printk("%s: insert %d\n", __func__, irq);
+//printk("%s: insert %d\n", __func__, irq);
 	return radix_tree_lookup(&irq_desc_tree, irq);
 }
 EXPORT_SYMBOL(irq_to_desc);


### PR DESCRIPTION
This allows us to directly inject the TSC frequency from the VMM.
Also turned off a print for the timer interrupts

Signed-off-by: GanShun ganshun@gmail.com
